### PR TITLE
Add oauth token type as an alternative to personal access tokens

### DIFF
--- a/art/_gitlab.py
+++ b/art/_gitlab.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import contextlib
+
+import click
+import requests
+from gitlab import exceptions as GitlabExceptions
+from gitlab import Gitlab
+
+from . import _config
+
+def get():
+    """
+    Create a GitLab API object from the current configuration
+    """
+
+    config = _config.load()
+    gitlab_url = config['gitlab_url']
+    token = config['token']
+    if config['token_type'] == 'private':
+        return Gitlab(gitlab_url, private_token=token)
+    if config['token_type'] == 'job':
+        return Gitlab(gitlab_url, job_token=token)
+    if config['token_type'] == 'oauth':
+        gitlab = Gitlab(gitlab_url, oauth_token=token)
+
+        # OAuth tokens are only valid for 2 hours. Verify that the stored
+        # token isn't expired
+        if token and test_token(gitlab):
+            return gitlab
+
+        # If expired, use the refresh token to get a new one
+        token = _config.refresh_token(config)
+        return Gitlab(gitlab_url, oauth_token=token)
+
+    raise _config.ConfigException('token_type', 'Unknown token type: {}'.format(config['token_type']))
+
+# Try to use the authentication token
+def test_token(gitlab):
+    """
+    Use GitLab's auth API endpoint to check for a valid access token
+
+    Returns True if the token can be used access the API.
+    """
+    with wrap_errors(gitlab, "Authentication failed"):
+        try:
+            gitlab.auth()
+            return True
+        except GitlabExceptions.GitlabAuthenticationError:
+            pass
+
+    return False
+
+@contextlib.contextmanager
+def wrap_errors(gitlab, fail_msg=None):
+    """Centralize common GitLab exception handling"""
+    try:
+        yield
+    except requests.exceptions.SSLError as exc:
+        raise click.ClickException('TLS connection to %s failed: %s' % (gitlab.url, exc))
+    except requests.exceptions.ConnectionError as exc:
+        raise click.ClickException('Connection to %s failed: %s' % (gitlab.url, exc))
+    except GitlabExceptions.GitlabAuthenticationError as exc:
+        raise click.ClickException('GitLab authentication failed: %s' % exc)
+    except GitlabExceptions.GitlabOperationError as exc:
+        msg = str(exc)
+        if fail_msg:
+            msg = '%s: %s' % (fail_msg, exc)
+
+        raise click.ClickException(msg)

--- a/art/_oauth.py
+++ b/art/_oauth.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+
+import time
+from urllib.parse import urljoin
+
+import requests
+
+# from RFC-8628 Section 3.4
+DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+DEFAULT_TIMEOUT = (5, 15)
+
+def _check_response(response):
+    """Attempt to decode an OAuth JSON response"""
+    # some versions of GitLab return HTTP error status codes for non-fatal errors
+    # the error detail is within the json response
+    try:
+        status = response.json()
+    except requests.exceptions.JSONDecodeError:
+        if not response.ok:
+            return ({}, response.reason, "invalid API response")
+        return ({}, "invalid API response", "")
+
+    error = status.get("error", None)
+    if error:
+        return ({}, error, status["error_description"])
+
+    return (status, None, None)
+
+def _wait_for_token(gitlab_url, client_id, device_code, poll_interval):
+    """
+    Poll the OAuth token endpoint, waiting for the user to complete authorization
+    """
+    while True:
+        response = requests.post(
+            urljoin(gitlab_url, "/oauth/token"),
+            data={
+                "grant_type": DEVICE_CODE_GRANT_TYPE,
+                "client_id": client_id,
+                "device_code": device_code
+            },
+            timeout=DEFAULT_TIMEOUT,
+            )
+
+        status, error, error_description = _check_response(response)
+
+        access_token = status.get("access_token", None)
+        refresh_token = status.get("refresh_token", None)
+        if access_token and refresh_token:
+            return (access_token, refresh_token)
+
+        if error == "authorization_pending":
+            pass
+        elif error == "slow_down":
+            poll_interval += 1
+        elif error_description:
+            print("Authentication failed:", error_description, "({})".format(error))
+            return (None, None)
+        else:
+            print("Authentication failed:", error)
+            return (None, None)
+
+        time.sleep(poll_interval)
+
+def authorize(gitlab_url, client_id):
+    """
+    Use GitLab's Device Grant Authorization flow to obtain an API access token for the
+    current user.
+    """
+    response = requests.post(
+        urljoin(gitlab_url, "/oauth/authorize_device"),
+        data={"client_id": client_id, "scope": "read_api"},
+        timeout=DEFAULT_TIMEOUT,
+        )
+
+    status, error, error_description = _check_response(response)
+    if not status:
+        print("Authentication failed:", error)
+        if error_description:
+            print(error_description)
+        return (None, None)
+
+    print("Authentication is required.")
+    print("Visit", status["verification_uri_complete"], "and verify this code:\n")
+    print("   ", status["user_code"], "\n")
+
+    return _wait_for_token(gitlab_url, client_id, status["device_code"], status["interval"])
+
+def refresh(gitlab_url, client_id, refresh_token):
+    """
+    Updates a GitLab OAuth token using the supplied refresh token and saves the new values to
+    the configuration file. A new authorization is attempted if the refresh token is not accepted.
+    """
+    # Skip directly to new authorization if the refresh token is invalid
+    if not refresh_token:
+        return authorize(gitlab_url, client_id)
+
+    response = requests.post(
+        urljoin(gitlab_url, "/oauth/token"),
+        data={
+            "grant_type": "refresh_token",
+            "client_id": client_id,
+            "refresh_token": refresh_token
+            },
+        timeout=DEFAULT_TIMEOUT,
+        )
+
+    status, error, _ = _check_response(response)
+    if not status:
+        print("Authentication failed:", error)
+        return authorize(gitlab_url, client_id)
+
+    return status["access_token"], status["refresh_token"]


### PR DESCRIPTION
Implement the OAuth 2.0 [Device Authorization Grant](https://docs.gitlab.com/api/oauth2/#device-authorization-grant-flow) that is available in [GitLab 17.2 or later](https://about.gitlab.com/releases/2024/07/18/gitlab-17-2-released/#oauth-20-device-authorization-grant-support). Users can authorize art to access their account using a web browser.

Closes #34 