### PR TITLE
Update python requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ A summary of significant changes within each version of `gitlab-art`.
 - ENH: New `art clean` command and `art update --clean` can be used to remove installed files.
 - ENH: The `art` command includes a top-level `-C, --change-dir DIR` option to set the working directory before loading `artifacts.yml` and installing files.
 - ENH: The `art` command incluces a top-level `-f, --file FILE` option to specify a different name or path to the `artifacts.yml` file.
+- ENH: Require Python >=3.7
+- ENH: Require python-gitlab >=3.12.0
 - BUG: The `appdirs` project has been replaced with `platformdirs`
 
 ## v0.4.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read_project_file(path):
 setup(
     name='gitlab-art',
     version=version,
-    python_requires='>=3.5',
+    python_requires='>=3.7',
     description='Gitlab artifact manager',
     long_description = read_project_file('README.md'),
     long_description_content_type = 'text/markdown',
@@ -24,7 +24,7 @@ setup(
         'PyYAML',
         'platformdirs',
         'click',
-        'python-gitlab>=1.12.0',
+        'python-gitlab>=3.12.0',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Update python-gitlab for generic package support. Pin minimum version to the version shipped in Debian Bookworm.

Update minimum Python version to 3.7 to match python-gitlab's requirement.